### PR TITLE
ozone/wayland: rebase v4l2 patch.

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-Add-support-for-V4L2VDA-on-Linux.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-Add-support-for-V4L2VDA-on-Linux.patch
@@ -44,10 +44,11 @@ Issue #437
  .../gpu_mjpeg_decode_accelerator_factory.cc   |  3 +-
  .../gpu_video_decode_accelerator_factory.cc   |  8 +++++
  .../gpu_video_decode_accelerator_factory.h    |  2 ++
- media/gpu/v4l2/BUILD.gn                       | 31 +++++++++++--------
+ media/gpu/v4l2/BUILD.gn                       | 35 +++++++++++--------
  media/gpu/v4l2/generic_v4l2_device.cc         |  6 +++-
- media/gpu/v4l2/v4l2_device.cc                 | 31 +++++++++++++++++++
- 8 files changed, 71 insertions(+), 15 deletions(-)
+ media/gpu/v4l2/v4l2_device.cc                 | 31 ++++++++++++++++
+ .../gpu/v4l2/v4l2_video_decode_accelerator.cc |  3 ++
+ 9 files changed, 76 insertions(+), 17 deletions(-)
 
 diff --git a/media/gpu/BUILD.gn b/media/gpu/BUILD.gn
 index 6eed6db69ad7..609f7afa1bdc 100644
@@ -163,10 +164,10 @@ index 74f10ebeb8a2..e779ef50fcbc 100644
    std::unique_ptr<VideoDecodeAccelerator> CreateVaapiVDA(
        const gpu::GpuDriverBugWorkarounds& workarounds,
 diff --git a/media/gpu/v4l2/BUILD.gn b/media/gpu/v4l2/BUILD.gn
-index 25b5c0dff8da..bb4fbbf3bef2 100644
+index 1ba24ce5e5d2..c50f6926e9b5 100644
 --- a/media/gpu/v4l2/BUILD.gn
 +++ b/media/gpu/v4l2/BUILD.gn
-@@ -28,31 +28,36 @@ source_set("v4l2") {
+@@ -28,33 +28,38 @@ source_set("v4l2") {
    sources = [
      "generic_v4l2_device.cc",
      "generic_v4l2_device.h",
@@ -185,6 +186,8 @@ index 25b5c0dff8da..bb4fbbf3bef2 100644
 -    "v4l2_mjpeg_decode_accelerator.h",
 -    "v4l2_slice_video_decode_accelerator.cc",
 -    "v4l2_slice_video_decode_accelerator.h",
+-    "v4l2_stateful_workaround.cc",
+-    "v4l2_stateful_workaround.h",
      "v4l2_video_decode_accelerator.cc",
      "v4l2_video_decode_accelerator.h",
      "v4l2_video_encode_accelerator.cc",
@@ -210,6 +213,8 @@ index 25b5c0dff8da..bb4fbbf3bef2 100644
 +      "v4l2_mjpeg_decode_accelerator.h",
 +      "v4l2_slice_video_decode_accelerator.cc",
 +      "v4l2_slice_video_decode_accelerator.h",
++      "v4l2_stateful_workaround.cc",
++      "v4l2_stateful_workaround.h",
 +    ]
 +  }
 +
@@ -319,6 +324,29 @@ index 65b3ae4b35e2..7a3b0bd645f7 100644
  
      default:
        DVLOGF(1) << "Unrecognized format " << FourccToString(format);
+diff --git a/media/gpu/v4l2/v4l2_video_decode_accelerator.cc b/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
+index 614b4c7a3e2a..e968e92cc3b6 100644
+--- a/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
++++ b/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
+@@ -31,6 +31,7 @@
+ #include "media/base/unaligned_shared_memory.h"
+ #include "media/base/video_frame_layout.h"
+ #include "media/base/video_types.h"
++#include "media/gpu/buildflags.h"
+ #include "media/gpu/image_processor_factory.h"
+ #include "media/gpu/macros.h"
+ #include "media/gpu/v4l2/v4l2_image_processor.h"
+@@ -318,8 +319,10 @@ bool V4L2VideoDecodeAccelerator::CheckConfig(const Config& config) {
+     return false;
+   }
+
++#if !BUILDFLAG(USE_LINUX_V4L2)
+   workarounds_ =
+       CreateV4L2StatefulWorkarounds(V4L2Device::Type::kDecoder, config.profile);
++#endif
+
+   output_mode_ = config.output_mode;
+
 -- 
 2.20.1
 


### PR DESCRIPTION
The patch that adds v4l2 support has been rebased. There
was an update, which added workouraounds for guado platform
(one of the chromebooks). The workaround does not seem
to be necessary on Linux platforms.

Signed-off-by: Maksim Sisov <msisov@igalia.com>